### PR TITLE
Skips feed's PlayerViewController

### DIFF
--- a/Tweak.x
+++ b/Tweak.x
@@ -46,6 +46,7 @@ static void DEMC_centerRenderingView();
 // New video played
 - (void)playbackController:(id)playbackController didActivateVideo:(id)video withPlaybackData:(id)playbackData {
     %orig;
+    if ([self.parentViewController isKindOfClass:NSClassFromString(@"YTInlineMutedPlaybackWatchViewController")]) return;
     isEngagementPanelVisible = NO;
     isEngagementPanelViewControllerRemoved = NO;
     if ([[self activeVideoPlayerOverlay] isFullscreen])

--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: me.foxster.donteatmycontent
 Name: DontEatMyContent
-Version: 1.1.11
+Version: 1.1.12
 Architecture: iphoneos-arm
 Description: Prevent the notch/Dynamic Island from munching on 2:1 video content in YouTube
 Maintainer: Foxster


### PR DESCRIPTION
Prevents feed player instances from being retained after dismissal, avoiding persistent audio that overlaps with newly opened players.