### PR TITLE
Fix duplicate constant symbol in Linux builds

### DIFF
--- a/Tweak.h
+++ b/Tweak.h
@@ -27,4 +27,4 @@
 
 void DEMC_showSnackBar(NSString *text);
 NSBundle *DEMC_getTweakBundle();
-CGFloat constant; // Makes rendering view a bit larger since constraining to safe area leaves a gap between the notch/Dynamic Island and video
+extern CGFloat constant; // Makes rendering view a bit larger since constraining to safe area leaves a gap between the notch/Dynamic Island and video

--- a/Tweak.x
+++ b/Tweak.x
@@ -1,5 +1,7 @@
 #import "Tweak.h"
 
+CGFloat constant;
+
 static CGFloat videoAspectRatio = 16/9;
 static BOOL isZoomedToFill = NO;
 static BOOL isEngagementPanelVisible = NO;


### PR DESCRIPTION
Change the shared constant declaration in Tweak.h to extern and define it in a single implementation file to avoid duplicate symbol linker errors.